### PR TITLE
use yew 0.18.0, instead of master branch

### DIFF
--- a/website/Cargo.toml
+++ b/website/Cargo.toml
@@ -22,7 +22,7 @@ wasm-opt = ['-Oz']
 
 [dependencies]
 serde_derive = "1.0.115"
-yew = { git = "https://github.com/yewstack/yew/", branch = "master"}
+yew = "0.18.0"
 yew-router = { git = "https://github.com/yewstack/yew/", branch = "master"}
 yewtil = { git = "https://github.com/yewstack/yew/", branch = "master" , features = ["pure", "neq", "effect", "future"] }
 wasm-bindgen = { version = "0.2.67", features = ["serde-serialize"]}

--- a/yew-material-utils/Cargo.toml
+++ b/yew-material-utils/Cargo.toml
@@ -22,7 +22,7 @@ serde_json = "1.0.61"
 lazy_static = { version = "1.4.0", features = ["spin_no_std"] }
 spin = "0.5.2"
 gloo-timers = { version = "0.2.1", features = ["futures"]}
-yew = { git = "https://github.com/yewstack/yew/", branch = "master" }
+yew = "0.18.0"
 yew-services = { git = "https://github.com/yewstack/yew/", branch = "master"}
 anyhow = "1.0"
 log = "0.4.6"

--- a/yew-material/Cargo.toml
+++ b/yew-material/Cargo.toml
@@ -49,9 +49,9 @@ serde_derive = "1.0.119"
 serde_json = "1.0.61"
 wasm-bindgen = { version = "0.2.69", features = ["serde-serialize"]}
 wasm-bindgen-futures = "0.4.19"
-yew = { git = "https://github.com/yewstack/yew/", branch = "master"}
-yewtil = { git = "https://github.com/yewstack/yew/", branch = "master" , features = ["pure", "neq", "future"] }
-yew-router = { git = "https://github.com/yewstack/yew/", branch = "master"}
+yew = "0.18.0"
+yewtil = { version = "0.4.0", features = ["pure", "neq", "future"] }
+yew-router = "0.15.0"
 yew-material-utils = { version = "0.1.23", path = "../yew-material-utils" }
 yew-material-macro = { version = "0.1.23", path = "../yew-material-macro" }
 
@@ -60,4 +60,3 @@ version = "0.3.46"
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3.19"
-


### PR DESCRIPTION
The compile error
```
error[E0433]: failed to resolve: use of undeclared type `App`
  --> src/test.rs:41:5
   |
41 |     App::<YNode>::new().mount_with_props(
   |     ^^^ use of undeclared type `App`

warning: unused import: `yew::prelude::*`
```
Use the tag version will fix this error.